### PR TITLE
Trello-63: Parse number values to be formatted for thousands

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -60,8 +60,8 @@
                               <tr v-for="(province, i) in provinces" :key="i" >
                                   <th scope="row">{{ i + 1}}</th>
                                   <td>{{ province.title }}</td>
-                                  <td>{{ province.cases }}</td>
-                                  <td>{{ province.deaths }}</td>
+                                  <td>{{ convertToPresentationalNumber(province.cases) }}</td>
+                                  <td>{{ convertToPresentationalNumber(province.deaths) }}</td>
                               </tr>
                           </tbody>
                       </mdb-tbl>
@@ -137,6 +137,7 @@ import EvolutionaryRecoverersByDay from './EvolutionaryRecoverersByDay'
 import NewCasesByDay from './NewCasesByDay'
 import {descending, asscending} from "@/tools/comparision";
 import { mapState }  from 'vuex'
+import { convertToPresentationalNumber } from '../tools/parses';
 
 export default {
 
@@ -173,7 +174,8 @@ export default {
       sort(column) {
           this.direction = !this.direction;
           this.column = column
-      }
+      },
+      convertToPresentationalNumber,
     },
     data () {
         return {

--- a/src/components/SVGMap.vue
+++ b/src/components/SVGMap.vue
@@ -17,8 +17,8 @@
     </svg>
         <div class="mapsvg-tooltip mapsvg-tt-bottom-right" v-if="currentProvince.title" v-bind:style="{left: mouseX + 'px', top: mouseY + 'px'}" style="position:absolute;min-width: 100px; left: 374px; top: 313px;"><!-- Region fields are available in this template -->
            <p>{{currentProvince.title}}</p>
-            <p>infectados: {{ currentProvince.cases }}</p>
-            <p>muertes: {{ currentProvince.deaths }}</p>
+            <p>infectados: {{ convertToPresentationalNumber(currentProvince.cases) }}</p>
+            <p>muertes: {{ convertToPresentationalNumber(currentProvince.deaths) }}</p>
         </div>
         <div class="map-leyenda container" >
             <ul class="list-group">
@@ -41,6 +41,7 @@
 
 <script>
     import { mapState }  from 'vuex'
+    import { convertToPresentationalNumber } from '../tools/parses';
 
     export default {
         name: "SVGMap",
@@ -83,7 +84,8 @@
                 this.touched = true;
                 this.mouseX = this.mobilePositionX;
                 this.mouseY = this.mobilePositionY;
-            }
+            },
+            convertToPresentationalNumber
         },
 
         mounted() {

--- a/src/store.js
+++ b/src/store.js
@@ -69,18 +69,18 @@ export const store = new Vuex.Store({
       }
     },
     positiveTotalCaseByDate(state) {
-      return  state.provincesStat.stats.reduce( (result, stat, currentIndex) => {
+      return state.provincesStat.stats.reduce( (result, stat, currentIndex) => {
         result.labels.push(stat.date)
 
         if(currentIndex > 0) {
           let prevIndex = currentIndex - 1
-          result.data.infects.push(  result.data.infects[prevIndex] + parseInt(stat.infects))
-          result.data.deaths.push( result.data.deaths[prevIndex] + parseInt(stat.deaths))
-          result.data.recoverers.push( result.data.recoverers[prevIndex] + parseInt(stat.recoverers))
+          result.data.infects.push(  result.data.infects[prevIndex] + parseInt(stat.infects, 10))
+          result.data.deaths.push( result.data.deaths[prevIndex] + parseInt(stat.deaths, 10))
+          result.data.recoverers.push( result.data.recoverers[prevIndex] + parseInt(stat.recoverers, 10))
         } else {
-          result.data.infects[currentIndex] = parseInt(stat.infects)
-          result.data.deaths[currentIndex] = parseInt(stat.deaths)
-          result.data.recoverers[currentIndex] = parseInt(stat.recoverers)
+          result.data.infects[currentIndex] = parseInt(stat.infects, 10)
+          result.data.deaths[currentIndex] = parseInt(stat.deaths, 10)
+          result.data.recoverers[currentIndex] = parseInt(stat.recoverers, 10)
         }
 
         return result

--- a/src/tools/parses.js
+++ b/src/tools/parses.js
@@ -1,0 +1,31 @@
+/**
+ * Returns the number value formatted for thousands
+ * i.e. from 2000 to 2,000
+ *
+ * @param {number | string } numberValue - value number to be parsed
+ * @returns {string} - parsed value
+ */
+export function convertToPresentationalNumber(numberValue) {
+  return `${numberValue}`.replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,');
+}
+
+/**
+ * Returns the items with the properties formatted for
+ * values of thousands. i.e. from 1000 to 1,000.
+ *
+ * @param {string[]} properties - list of properties to be parse
+ * @returns {function(Object[]): Object[]} - list with the parsed values
+ */
+export function parseToNumbers(properties) {
+  properties = [].concat(properties);
+  return function parse(items) {
+    return items.map(item => {
+      properties.forEach(property => {
+        if (item[property]) {
+          item[property] = convertToPresentationalNumber(item[property]);
+        }
+      });
+      return item;
+    })
+  }
+}


### PR DESCRIPTION
- Formatting the values of the numbers to support thousands.
- Add radix of the parseInt use to prevent undesired behavior.

<img width="1242" alt="Estado actual del Coronavirus en REP DOM  2020-04-19 22-25-39" src="https://user-images.githubusercontent.com/7207257/79708521-98932080-828d-11ea-811d-a44175825714.png">

![Screen Shot 2020-04-19 at 10 25 22 PM](https://user-images.githubusercontent.com/7207257/79708525-9a5ce400-828d-11ea-9ff8-38a561fbaa75.png)
